### PR TITLE
Add skills, dark mode, writing section, and UI polish

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -28,11 +28,13 @@ header {
 
 nav {
     display: flex;
+    align-items: center;
     justify-content: center;
     gap: 2rem;
     padding: 1rem 2rem;
     max-width: 1200px;
     margin: 0 auto;
+    flex-wrap: wrap;
 }
 
 nav a {
@@ -55,6 +57,51 @@ nav a:focus {
 nav a.active {
     color: #0066cc;
     border-bottom: 2px solid #0066cc;
+}
+
+/* Theme toggle */
+.theme-toggle {
+    background: none;
+    border: 1px solid #e0e0e0;
+    border-radius: 6px;
+    cursor: pointer;
+    padding: 0.4rem;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    transition: background 0.2s, border-color 0.2s;
+}
+
+.theme-toggle:hover {
+    background: #f0f0f0;
+    border-color: #ccc;
+}
+
+.theme-toggle:focus {
+    outline: 2px solid #0066cc;
+    outline-offset: 2px;
+}
+
+.theme-toggle svg {
+    stroke: #555;
+    fill: none;
+    stroke-width: 2;
+    stroke-linecap: round;
+    stroke-linejoin: round;
+}
+
+.icon-moon {
+    display: none;
+}
+
+[data-theme="dark"] .icon-sun {
+    display: none;
+}
+
+[data-theme="dark"] .icon-moon {
+    display: block;
+    fill: #e0e0e0;
+    stroke: #e0e0e0;
 }
 
 /* Main content */
@@ -168,6 +215,45 @@ h2 {
     border-radius: 50%;
 }
 
+/* Skills section */
+.skills-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+    gap: 1.5rem;
+    margin-top: 1rem;
+}
+
+.skill-category h3 {
+    font-size: 0.95rem;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: #555;
+    margin-bottom: 0.75rem;
+}
+
+.skill-tags {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+}
+
+.skill-tag {
+    display: inline-block;
+    padding: 0.35rem 0.75rem;
+    background: #f0f4f8;
+    color: #333;
+    border-radius: 4px;
+    font-size: 0.85rem;
+    font-weight: 500;
+    border: 1px solid #e0e0e0;
+    transition: background 0.2s, border-color 0.2s;
+}
+
+.skill-tag:hover {
+    background: #e0eaf4;
+    border-color: #0066cc;
+}
+
 /* Projects grid */
 .project-grid {
     display: grid;
@@ -200,6 +286,24 @@ h2 {
     color: #666;
 }
 
+.project-tags {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.4rem;
+    margin-bottom: 1rem;
+}
+
+.project-tag {
+    display: inline-block;
+    padding: 0.2rem 0.6rem;
+    background: #f0f4f8;
+    color: #555;
+    border-radius: 3px;
+    font-size: 0.75rem;
+    font-weight: 500;
+    border: 1px solid #e0e0e0;
+}
+
 .project-link {
     color: #0066cc;
     text-decoration: none;
@@ -212,6 +316,52 @@ h2 {
 }
 
 .project-link:focus {
+    outline: 2px solid #0066cc;
+    outline-offset: 2px;
+}
+
+/* Writing section */
+.writing-grid {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 1.5rem;
+    margin-top: 1rem;
+    justify-content: center;
+}
+
+.writing-card {
+    max-width: 504px;
+    width: 100%;
+}
+
+.writing-embed {
+    border-radius: 8px;
+    overflow: hidden;
+    border: 1px solid #e0e0e0;
+}
+
+.writing-embed iframe {
+    display: block;
+    max-width: 100%;
+}
+
+.writing-more {
+    margin-top: 1.5rem;
+    text-align: center;
+}
+
+.writing-more a {
+    color: #0066cc;
+    text-decoration: none;
+    font-weight: 500;
+}
+
+.writing-more a:hover,
+.writing-more a:focus {
+    text-decoration: underline;
+}
+
+.writing-more a:focus {
     outline: 2px solid #0066cc;
     outline-offset: 2px;
 }
@@ -277,6 +427,150 @@ h2 {
     color: #999;
 }
 
+/* Scroll reveal animations */
+.fade-in {
+    opacity: 0;
+    transform: translateY(20px);
+    transition: opacity 0.6s ease-out, transform 0.6s ease-out;
+}
+
+.fade-in.visible {
+    opacity: 1;
+    transform: translateY(0);
+}
+
+/* Reduce motion for users who prefer it */
+@media (prefers-reduced-motion: reduce) {
+    .fade-in {
+        opacity: 1;
+        transform: none;
+        transition: none;
+    }
+}
+
+/* Dark mode */
+[data-theme="dark"] body {
+    color: #e0e0e0;
+    background-color: #1a1a1a;
+}
+
+[data-theme="dark"] header {
+    background: #1e1e1e;
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.3);
+}
+
+[data-theme="dark"] nav a {
+    color: #b0b0b0;
+}
+
+[data-theme="dark"] nav a:hover,
+[data-theme="dark"] nav a:focus {
+    color: #4d9fff;
+}
+
+[data-theme="dark"] nav a.active {
+    color: #4d9fff;
+    border-bottom-color: #4d9fff;
+}
+
+[data-theme="dark"] .theme-toggle {
+    border-color: #444;
+}
+
+[data-theme="dark"] .theme-toggle:hover {
+    background: #333;
+    border-color: #555;
+}
+
+[data-theme="dark"] main {
+    background-color: #1e1e1e;
+    box-shadow: 0 0 30px rgba(0, 0, 0, 0.5);
+}
+
+[data-theme="dark"] h2 {
+    color: #e0e0e0;
+}
+
+[data-theme="dark"] .about-list li::before {
+    background: #4d9fff;
+}
+
+[data-theme="dark"] .skill-category h3 {
+    color: #999;
+}
+
+[data-theme="dark"] .skill-tag {
+    background: #2a2a2a;
+    color: #d0d0d0;
+    border-color: #444;
+}
+
+[data-theme="dark"] .skill-tag:hover {
+    background: #333;
+    border-color: #4d9fff;
+}
+
+[data-theme="dark"] .project-card {
+    border-color: #444;
+    border-left-color: #4d9fff;
+}
+
+[data-theme="dark"] .project-card:hover {
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+    border-left-color: #3a8ae6;
+}
+
+[data-theme="dark"] .project-card h3 {
+    color: #e0e0e0;
+}
+
+[data-theme="dark"] .project-card p {
+    color: #999;
+}
+
+[data-theme="dark"] .project-tag {
+    background: #2a2a2a;
+    color: #b0b0b0;
+    border-color: #444;
+}
+
+[data-theme="dark"] .project-link {
+    color: #4d9fff;
+}
+
+[data-theme="dark"] .writing-embed {
+    border-color: #444;
+}
+
+[data-theme="dark"] .writing-more a {
+    color: #4d9fff;
+}
+
+[data-theme="dark"] #contact {
+    background: #171717;
+}
+
+[data-theme="dark"] .contact-item {
+    background: #1e1e1e;
+    border-color: #444;
+    border-left-color: #4d9fff;
+    color: #e0e0e0;
+}
+
+[data-theme="dark"] .contact-item:hover,
+[data-theme="dark"] .contact-item:focus {
+    box-shadow: 0 4px 16px rgba(0, 0, 0, 0.3);
+    border-left-color: #3a8ae6;
+}
+
+[data-theme="dark"] .contact-item svg {
+    fill: #4d9fff;
+}
+
+[data-theme="dark"] .copyright {
+    color: #666;
+}
+
 /* Responsive */
 @media (max-width: 600px) {
     nav {
@@ -311,6 +605,10 @@ h2 {
         padding: 1rem 1.5rem;
         min-width: 120px;
     }
+
+    .skills-grid {
+        grid-template-columns: 1fr;
+    }
 }
 
 /* Print styles */
@@ -342,8 +640,14 @@ h2 {
         text-shadow: none;
     }
 
-    .hero-cta {
+    .hero-cta,
+    .theme-toggle {
         display: none;
+    }
+
+    .fade-in {
+        opacity: 1;
+        transform: none;
     }
 
     .profile-pic {

--- a/index.html
+++ b/index.html
@@ -26,8 +26,14 @@
     <header>
         <nav>
             <a href="#about">About</a>
+            <a href="#skills">Skills</a>
             <a href="#projects">Projects</a>
+            <a href="#writing">Writing</a>
             <a href="#contact">Contact</a>
+            <button class="theme-toggle" id="themeToggle" aria-label="Toggle dark mode">
+                <svg class="icon-sun" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="20" height="20"><path d="M12 7a5 5 0 100 10 5 5 0 000-10zM12 1v2m0 18v2M4.22 4.22l1.42 1.42m12.72 12.72l1.42 1.42M1 12h2m18 0h2M4.22 19.78l1.42-1.42M18.36 5.64l1.42-1.42"/></svg>
+                <svg class="icon-moon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="20" height="20"><path d="M21 12.79A9 9 0 1111.21 3 7 7 0 0021 12.79z"/></svg>
+            </button>
         </nav>
     </header>
 
@@ -43,7 +49,7 @@
             </div>
         </section>
 
-        <section id="about">
+        <section id="about" class="fade-in">
             <h2>About Me</h2>
             <p>
                 I'm a .NET backend engineer with 11 years of experience designing and building scalable systems in Microsoft Azure. I thrive on solving complex problems—whether that means architecting resilient integrations, debugging tricky production issues, or optimizing workflows for dramatic performance gains.
@@ -57,30 +63,127 @@
             </ul>
         </section>
 
-        <section id="projects">
+        <section id="skills" class="fade-in">
+            <h2>Tech Stack</h2>
+            <div class="skills-grid">
+                <div class="skill-category">
+                    <h3>Languages</h3>
+                    <div class="skill-tags">
+                        <span class="skill-tag">C#</span>
+                        <span class="skill-tag">JavaScript</span>
+                        <span class="skill-tag">TypeScript</span>
+                        <span class="skill-tag">SQL</span>
+                        <span class="skill-tag">PowerShell</span>
+                    </div>
+                </div>
+                <div class="skill-category">
+                    <h3>Backend</h3>
+                    <div class="skill-tags">
+                        <span class="skill-tag">.NET Core</span>
+                        <span class="skill-tag">.NET Framework</span>
+                        <span class="skill-tag">Entity Framework</span>
+                        <span class="skill-tag">REST APIs</span>
+                        <span class="skill-tag">Webhooks</span>
+                        <span class="skill-tag">MVC</span>
+                    </div>
+                </div>
+                <div class="skill-category">
+                    <h3>Azure</h3>
+                    <div class="skill-tags">
+                        <span class="skill-tag">Functions</span>
+                        <span class="skill-tag">Service Bus</span>
+                        <span class="skill-tag">CosmosDB</span>
+                        <span class="skill-tag">API Gateway</span>
+                        <span class="skill-tag">Key Vault</span>
+                        <span class="skill-tag">Entra</span>
+                        <span class="skill-tag">Event Grid</span>
+                        <span class="skill-tag">App Insights</span>
+                    </div>
+                </div>
+                <div class="skill-category">
+                    <h3>Frontend</h3>
+                    <div class="skill-tags">
+                        <span class="skill-tag">VueJS</span>
+                        <span class="skill-tag">AngularJS</span>
+                        <span class="skill-tag">HTML</span>
+                        <span class="skill-tag">CSS / SASS</span>
+                        <span class="skill-tag">Webpack</span>
+                    </div>
+                </div>
+                <div class="skill-category">
+                    <h3>Database</h3>
+                    <div class="skill-tags">
+                        <span class="skill-tag">MS SQL</span>
+                        <span class="skill-tag">CosmosDB</span>
+                        <span class="skill-tag">RavenDB</span>
+                    </div>
+                </div>
+                <div class="skill-category">
+                    <h3>DevOps & Tools</h3>
+                    <div class="skill-tags">
+                        <span class="skill-tag">CI/CD</span>
+                        <span class="skill-tag">Git</span>
+                        <span class="skill-tag">Azure DevOps</span>
+                        <span class="skill-tag">Docker</span>
+                        <span class="skill-tag">GitHub</span>
+                    </div>
+                </div>
+                <div class="skill-category">
+                    <h3>Testing</h3>
+                    <div class="skill-tags">
+                        <span class="skill-tag">XUnit</span>
+                        <span class="skill-tag">NUnit</span>
+                        <span class="skill-tag">FluentAssertions</span>
+                        <span class="skill-tag">Moq</span>
+                        <span class="skill-tag">Postman</span>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <section id="projects" class="fade-in">
             <h2>Projects</h2>
             <div class="project-grid">
                 <article class="project-card">
                     <h3>Conway's Game of Life</h3>
                     <p>Interactive cellular automaton simulation built with JavaScript and HTML Canvas. Features preset patterns, step-through controls, and a toroidal grid.</p>
+                    <div class="project-tags">
+                        <span class="project-tag">JavaScript</span>
+                        <span class="project-tag">HTML Canvas</span>
+                        <span class="project-tag">CSS</span>
+                    </div>
                     <a href="https://lwalden.github.io/life/" class="project-link" target="_blank" rel="noopener">View Project</a>
                 </article>
 
                 <article class="project-card">
-                    <h3>Project Two</h3>
-                    <p>Brief description of the project and technologies used.</p>
-                    <a href="#" class="project-link">View Project</a>
-                </article>
-
-                <article class="project-card">
-                    <h3>Project Three</h3>
-                    <p>Brief description of the project and technologies used.</p>
-                    <a href="#" class="project-link">View Project</a>
+                    <h3>Claude Code Quick Start Template</h3>
+                    <p>Project template that gives Claude Code session memory, structured planning, and security-conscious permissions. Includes custom slash commands for planning, setup, and session management.</p>
+                    <div class="project-tags">
+                        <span class="project-tag">Claude Code</span>
+                        <span class="project-tag">AI Tooling</span>
+                        <span class="project-tag">GitHub Actions</span>
+                        <span class="project-tag">Developer Tools</span>
+                    </div>
+                    <a href="https://github.com/lwalden/claude-code-quick-start-template" class="project-link" target="_blank" rel="noopener">View Project</a>
                 </article>
             </div>
         </section>
 
-        <section id="contact">
+        <section id="writing" class="fade-in">
+            <h2>Writing</h2>
+            <div class="writing-grid">
+                <article class="writing-card">
+                    <div class="writing-embed">
+                        <iframe src="https://www.linkedin.com/embed/feed/update/urn:li:share:7426023758370578432?collapsed=1" height="564" width="504" frameborder="0" allowfullscreen="" title="Embedded post"></iframe>
+                    </div>
+                </article>
+            </div>
+            <p class="writing-more">
+                <a href="https://www.linkedin.com/in/laurancewalden/recent-activity/all/" target="_blank" rel="noopener">View all posts on LinkedIn</a>
+            </p>
+        </section>
+
+        <section id="contact" class="fade-in">
             <h2>Get in Touch</h2>
             <p>Interested in working together? Feel free to reach out.</p>
             <div class="contact-grid">
@@ -101,7 +204,7 @@
                     <span>Resume</span>
                 </a>
             </div>
-            <p class="copyright">&copy; 2025 Laurance Walden</p>
+            <p class="copyright">&copy; <script>document.write(new Date().getFullYear())</script> Laurance Walden</p>
         </section>
     </main>
 
@@ -116,7 +219,6 @@
             const documentHeight = document.documentElement.scrollHeight;
             const isAtBottom = window.scrollY + windowHeight >= documentHeight - 10;
 
-            // If at bottom of page, activate last nav link
             if (isAtBottom) {
                 navLinks.forEach(link => link.classList.remove('active'));
                 const lastNavLink = navLinks[navLinks.length - 1];
@@ -142,6 +244,39 @@
 
         window.addEventListener('scroll', updateActiveNav);
         updateActiveNav();
+
+        // Dark mode toggle
+        const themeToggle = document.getElementById('themeToggle');
+        const prefersDark = window.matchMedia('(prefers-color-scheme: dark)');
+
+        function setTheme(dark) {
+            document.documentElement.setAttribute('data-theme', dark ? 'dark' : 'light');
+            localStorage.setItem('theme', dark ? 'dark' : 'light');
+        }
+
+        // Initialize: saved preference > OS preference > light
+        const saved = localStorage.getItem('theme');
+        if (saved) {
+            setTheme(saved === 'dark');
+        } else {
+            setTheme(prefersDark.matches);
+        }
+
+        themeToggle.addEventListener('click', () => {
+            const isDark = document.documentElement.getAttribute('data-theme') === 'dark';
+            setTheme(!isDark);
+        });
+
+        // Scroll reveal animations
+        const observer = new IntersectionObserver((entries) => {
+            entries.forEach(entry => {
+                if (entry.isIntersecting) {
+                    entry.target.classList.add('visible');
+                }
+            });
+        }, { threshold: 0.1 });
+
+        document.querySelectorAll('.fade-in').forEach(el => observer.observe(el));
     </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- **Tech Stack section**: 7 categories (Languages, Backend, Azure, Frontend, Database, DevOps, Testing) pulled from resume, displayed as a responsive tag grid
- **Dark mode**: Toggle in nav with sun/moon icons, respects OS preference, persists via localStorage, full theme coverage for all sections
- **Writing section**: Embedded LinkedIn post with link to full activity feed, structured for easy updates
- **Project cards**: Replaced placeholders with real projects (Claude Code Quick Start Template), added tech tags to both cards, removed empty Project Three
- **Scroll animations**: Fade-in reveal on scroll with `prefers-reduced-motion` support
- **Evergreen copyright**: Year auto-updates via JavaScript

## Test plan
- [ ] Verify all sections render correctly in light mode
- [ ] Toggle dark mode and verify all sections theme properly
- [ ] Refresh page and confirm dark mode preference persists
- [ ] Test on mobile viewport (nav wraps, skills grid stacks to single column)
- [ ] Scroll through page and confirm fade-in animations trigger
- [ ] Verify LinkedIn embed loads and is interactive
- [ ] Check print styles (toggle and animations hidden, content visible)

🤖 Generated with [Claude Code](https://claude.com/claude-code)