### PR TITLE
Fix dark mode project titles and skill tag styling

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -223,14 +223,6 @@ h2 {
     margin-top: 1rem;
 }
 
-.skill-category {
-    padding: 1rem 1.25rem;
-    background: #fff;
-    border: 1px solid #e0e0e0;
-    border-left: 4px solid #0066cc;
-    border-radius: 8px;
-}
-
 .skill-category h3 {
     font-size: 0.8rem;
     text-transform: uppercase;
@@ -250,10 +242,11 @@ h2 {
     padding: 0.25rem 0.6rem;
     background: #fff;
     color: #333;
-    border-radius: 4px;
+    border-radius: 6px;
     font-size: 0.85rem;
     font-weight: 500;
     border: 1px solid #e0e0e0;
+    border-left: 3px solid #0066cc;
     transition: background 0.2s, border-color 0.2s;
 }
 
@@ -506,12 +499,6 @@ h2 {
     background: #4d9fff;
 }
 
-[data-theme="dark"] .skill-category {
-    background: #1e1e1e;
-    border-color: #444;
-    border-left-color: #4d9fff;
-}
-
 [data-theme="dark"] .skill-category h3 {
     color: #999;
 }
@@ -520,6 +507,7 @@ h2 {
     background: #2a2a2a;
     color: #d0d0d0;
     border-color: #444;
+    border-left-color: #4d9fff;
 }
 
 [data-theme="dark"] .skill-tag:hover {
@@ -538,7 +526,7 @@ h2 {
 }
 
 [data-theme="dark"] .project-card h3 {
-    color: #fff;
+    color: #333;
 }
 
 [data-theme="dark"] .project-card p {


### PR DESCRIPTION
## Summary
- Fixed project card titles invisible in dark mode (white text on white background -> dark text)
- Moved blue left border and rounded corner styling from skill-category containers to individual skill-tag spans
- Added matching blue left border to skill tags in dark mode

## Test plan
- [ ] Verify project card titles ("Conway's Game of Life", etc.) are visible in dark mode
- [ ] Confirm individual skill tags have blue left border and rounded corners in light mode
- [ ] Confirm skill tags have blue left border in dark mode
- [ ] Verify skill-category containers no longer have card-style borders

🤖 Generated with [Claude Code](https://claude.com/claude-code)