### PR TITLE
Code review fixes: dark mode, performance, and HTML cleanup

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -106,7 +106,6 @@ nav a.active {
 
 /* Main content */
 main {
-    padding-top: 58px;
     background-color: #f5f6f8;
     max-width: 1200px;
     margin: 0 auto;
@@ -259,7 +258,9 @@ h2 {
 
 .skill-tag:hover {
     background: #e0eaf4;
-    border-color: #0066cc;
+    border-top-color: #0066cc;
+    border-right-color: #0066cc;
+    border-bottom-color: #0066cc;
 }
 
 /* Projects grid */
@@ -354,6 +355,7 @@ h2 {
 .writing-embed iframe {
     display: block;
     max-width: 100%;
+    border: 0;
 }
 
 .writing-more {
@@ -524,10 +526,13 @@ h2 {
 
 [data-theme="dark"] .skill-tag:hover {
     background: #333;
-    border-color: #4d9fff;
+    border-top-color: #4d9fff;
+    border-right-color: #4d9fff;
+    border-bottom-color: #4d9fff;
 }
 
 [data-theme="dark"] .project-card {
+    background: #1e1e1e;
     border-color: #444;
     border-left-color: #4d9fff;
 }
@@ -538,7 +543,7 @@ h2 {
 }
 
 [data-theme="dark"] .project-card h3 {
-    color: #fff;
+    color: #e0e0e0;
 }
 
 [data-theme="dark"] .project-card p {
@@ -556,7 +561,9 @@ h2 {
 }
 
 [data-theme="dark"] .writing-embed {
+    background: #1e1e1e;
     border-color: #444;
+    border-left-color: #4d9fff;
 }
 
 [data-theme="dark"] .writing-more a {

--- a/index.html
+++ b/index.html
@@ -80,7 +80,7 @@
         <section id="about" class="fade-in">
             <h2>About Me</h2>
             <p>
-                I'm a .NET backend engineer with 11 years of experience designing and building scalable systems in Microsoft Azure. I thrive on solving complex problems—whether that means architecting resilient integrations, debugging tricky production issues, or optimizing workflows for dramatic performance gains.
+                I'm a .NET backend engineer with 12 years of experience designing and building scalable systems in Microsoft Azure. I thrive on solving complex problems—whether that means architecting resilient integrations, debugging tricky production issues, or optimizing workflows for dramatic performance gains.
             </p>
             <ul class="about-list">
                 <li><strong>Architecture & Design:</strong> Event-driven microservices, APIs, and system integrations</li>
@@ -95,6 +95,16 @@
             <h2>Tech Stack / Skills</h2>
             <div class="skills-grid">
                 <div class="skill-category">
+                    <h3>AI & Agentic</h3>
+                    <div class="skill-tags">
+                        <span class="skill-tag">Claude Code</span>
+                        <span class="skill-tag">GitHub Copilot</span>
+                        <span class="skill-tag">Context Engineering</span>
+                        <span class="skill-tag">Prompt Engineering</span>
+                        <span class="skill-tag">Agent Orchestration</span>
+                    </div>
+                </div>
+                <div class="skill-category">
                     <h3>Languages</h3>
                     <div class="skill-tags">
                         <span class="skill-tag">C#</span>
@@ -102,6 +112,24 @@
                         <span class="skill-tag">TypeScript</span>
                         <span class="skill-tag">SQL</span>
                         <span class="skill-tag">PowerShell</span>
+                    </div>
+                </div>
+                <div class="skill-category">
+                    <h3>DevOps & Tools</h3>
+                    <div class="skill-tags">
+                        <span class="skill-tag">CI/CD</span>
+                        <span class="skill-tag">Git</span>
+                        <span class="skill-tag">GitHub Actions</span>
+                        <span class="skill-tag">Azure DevOps</span>
+                        <span class="skill-tag">Docker</span>
+                    </div>
+                </div>
+                <div class="skill-category">
+                    <h3>Database</h3>
+                    <div class="skill-tags">
+                        <span class="skill-tag">MS SQL</span>
+                        <span class="skill-tag">CosmosDB</span>
+                        <span class="skill-tag">RavenDB</span>
                     </div>
                 </div>
                 <div class="skill-category">
@@ -140,34 +168,6 @@
                         <span class="skill-tag">HTML</span>
                         <span class="skill-tag">CSS / SASS</span>
                         <span class="skill-tag">Webpack</span>
-                    </div>
-                </div>
-                <div class="skill-category">
-                    <h3>Database</h3>
-                    <div class="skill-tags">
-                        <span class="skill-tag">MS SQL</span>
-                        <span class="skill-tag">CosmosDB</span>
-                        <span class="skill-tag">RavenDB</span>
-                    </div>
-                </div>
-                <div class="skill-category">
-                    <h3>AI & Agentic</h3>
-                    <div class="skill-tags">
-                        <span class="skill-tag">Claude Code</span>
-                        <span class="skill-tag">GitHub Copilot</span>
-                        <span class="skill-tag">Context Engineering</span>
-                        <span class="skill-tag">Prompt Engineering</span>
-                        <span class="skill-tag">Agent Orchestration</span>
-                    </div>
-                </div>
-                <div class="skill-category">
-                    <h3>DevOps & Tools</h3>
-                    <div class="skill-tags">
-                        <span class="skill-tag">CI/CD</span>
-                        <span class="skill-tag">Git</span>
-                        <span class="skill-tag">GitHub Actions</span>
-                        <span class="skill-tag">Azure DevOps</span>
-                        <span class="skill-tag">Docker</span>
                     </div>
                 </div>
                 <div class="skill-category">
@@ -217,7 +217,7 @@
             <div class="writing-grid">
                 <article class="writing-card">
                     <div class="writing-embed">
-                        <iframe src="https://www.linkedin.com/embed/feed/update/urn:li:share:7426023758370578432?collapsed=1" height="564" width="504" frameborder="0" allowfullscreen="" title="Embedded post" loading="lazy"></iframe>
+                        <iframe src="https://www.linkedin.com/embed/feed/update/urn:li:share:7426023758370578432?collapsed=1" height="564" width="504" allowfullscreen title="Embedded post" loading="lazy"></iframe>
                     </div>
                 </article>
             </div>
@@ -247,14 +247,26 @@
                     <span>Resume</span>
                 </a>
             </div>
-            <p class="copyright">&copy; <script>document.write(new Date().getFullYear())</script> Laurance Walden</p>
+            <p class="copyright">&copy; <span id="year"></span> Laurance Walden</p>
         </section>
     </main>
 
     <script>
+        // Copyright year
+        document.getElementById('year').textContent = new Date().getFullYear();
+
+        // Dynamic header offset
+        function updateHeaderOffset() {
+            const header = document.querySelector('header');
+            document.querySelector('main').style.paddingTop = header.offsetHeight + 'px';
+        }
+        updateHeaderOffset();
+        window.addEventListener('resize', updateHeaderOffset);
+
         // Scroll spy for nav active states
         const sections = document.querySelectorAll('section[id]');
         const navLinks = document.querySelectorAll('nav a');
+        let scrollTicking = false;
 
         function updateActiveNav() {
             const scrollPos = window.scrollY + 100;
@@ -269,23 +281,32 @@
                 return;
             }
 
-            sections.forEach(section => {
+            let activeId = null;
+            for (const section of sections) {
                 const top = section.offsetTop;
                 const height = section.offsetHeight;
-                const id = section.getAttribute('id');
-
                 if (scrollPos >= top && scrollPos < top + height) {
-                    navLinks.forEach(link => {
-                        link.classList.remove('active');
-                        if (link.getAttribute('href') === '#' + id) {
-                            link.classList.add('active');
-                        }
-                    });
+                    activeId = section.getAttribute('id');
+                    break;
                 }
-            });
+            }
+
+            if (activeId) {
+                navLinks.forEach(link => {
+                    link.classList.toggle('active', link.getAttribute('href') === '#' + activeId);
+                });
+            }
         }
 
-        window.addEventListener('scroll', updateActiveNav);
+        window.addEventListener('scroll', () => {
+            if (!scrollTicking) {
+                requestAnimationFrame(() => {
+                    updateActiveNav();
+                    scrollTicking = false;
+                });
+                scrollTicking = true;
+            }
+        });
         updateActiveNav();
 
         // Dark mode toggle


### PR DESCRIPTION
## Summary
- Fixed About section years mismatch (11 -> 12 to match meta description)
- Replaced deprecated `frameborder` attribute with CSS `border: 0`
- Replaced `document.write()` with safer `span`/`textContent` for copyright year
- Fixed skill-tag hover to preserve blue left border accent (light + dark mode)
- Added dark mode styles for writing embed (background + blue left border)
- Added dark mode background to project cards to match contact tiles
- Replaced hardcoded `padding-top: 58px` with dynamic header height calculation
- Throttled scroll listener with `requestAnimationFrame`
- Fixed scroll spy loop to `break` on first match
- Reordered skill categories for balanced desktop layout (AI & Agentic first)

## Test plan
- [ ] Verify About section says "12 years"
- [ ] Check copyright year renders correctly
- [ ] Confirm iframe has no visible border
- [ ] Verify skill-tag blue left border stays on hover in both themes
- [ ] Check writing embed has dark background + blue left border in dark mode
- [ ] Confirm project cards match contact tile styling in dark mode
- [ ] Verify content not hidden behind header at various widths
- [ ] Confirm scroll spy highlights correct nav link while scrolling
- [ ] Check skill category order balances on desktop

🤖 Generated with [Claude Code](https://claude.com/claude-code)