### PR TITLE
Fix nav scroll offset clipping section headers

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -116,6 +116,7 @@ section {
     padding: 2.5rem 2rem;
     max-width: 900px;
     margin: 0 auto;
+    scroll-margin-top: var(--header-height, 60px);
 }
 
 /* Hero section */

--- a/index.html
+++ b/index.html
@@ -258,7 +258,9 @@
         // Dynamic header offset
         function updateHeaderOffset() {
             const header = document.querySelector('header');
-            document.querySelector('main').style.paddingTop = header.offsetHeight + 'px';
+            const height = header.offsetHeight + 'px';
+            document.querySelector('main').style.paddingTop = height;
+            document.documentElement.style.setProperty('--header-height', height);
         }
         updateHeaderOffset();
         window.addEventListener('resize', updateHeaderOffset);


### PR DESCRIPTION
## Summary
- Section headers were hidden behind the fixed nav bar when clicking menu links
- Added `scroll-margin-top` to sections using a CSS variable (`--header-height`) set dynamically from the actual header height
- Adapts correctly on resize (e.g. when nav wraps on smaller screens)

## Test plan
- [ ] Click each nav link and verify the section header is fully visible below the nav bar
- [ ] Resize the browser to trigger nav wrapping and verify scroll offset adjusts
- [ ] Test on mobile viewport

🤖 Generated with [Claude Code](https://claude.com/claude-code)